### PR TITLE
add activity feed API

### DIFF
--- a/darwin/system/packages.nix
+++ b/darwin/system/packages.nix
@@ -1,5 +1,6 @@
 {pkgs, ...}: {
   environment.systemPackages = with pkgs; [
+    graphite-cli
     imagemagick
     nil
     (symlinkJoin {

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR
Added a basic Express.js server with mock activity feed and installed Graphite CLI

### What changed?
- Created a new Express.js server with a `/feed` endpoint that returns mock activity data
- Added `graphite-cli` to system packages in Nix configuration

### How to test?
1. Start the server: `node graphite-demo/server.js`
2. Visit `http://localhost:3000/feed` in your browser or use curl
3. Verify that the JSON response contains three mock activity items
4. Confirm Graphite CLI is available by running `gt --version`

### Why make this change?
This sets up the foundation for a demo activity feed service and adds tooling for version control workflow management through Graphite CLI, enabling better development and testing of social feed functionality.